### PR TITLE
Add applicationinsights-spring-boot-starter dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,12 @@
                 <scope>runtime</scope>
             </dependency>
             <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>applicationinsights-spring-boot-starter</artifactId>
+                <version>2.6.2</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
@@ -102,6 +108,10 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>applicationinsights-spring-boot-starter</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
If in a subproject you want to activate application insights you need to add to the application.properties

`
azure.application-insights.instrumentation-key=<your-ai-key-from-env>
`

For all the other parameters please refer to the [documentation](https://github.com/microsoft/ApplicationInsights-Java/tree/2.6.2/azure-application-insights-spring-boot-starter#configure-more-parameters-using-applicationproperties).